### PR TITLE
New chips for libtoprammer

### DIFF
--- a/RUNTIME_IDS
+++ b/RUNTIME_IDS
@@ -19,6 +19,7 @@
 0x000A		=> hm62256dip28
 0x000B		=> m24c16dip8
 0x000C		=> 27cxxxdip28
+0x000C		=> 27cxxxdip40
 0xDE01		=> pic10fxxxdip8
 0xDE02		=> microchip01dip8
 0xDE03		=> microchip01dip14dip20

--- a/libtoprammer/chips/_27c1024.py
+++ b/libtoprammer/chips/_27c1024.py
@@ -1,0 +1,298 @@
+"""
+#    TOP2049 Open Source programming suite
+#
+#    27c16dip1024  UV/OTP EPROM
+#
+#    Copyright (c) 2012 Michael Buesch <m@bues.ch>
+#    Copyright (c) 2016 Tom van Leeuwen <gpl@tomvanleeuwen.nl>
+#
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License along
+#    with this program; if not, write to the Free Software Foundation, Inc.,
+#    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+from libtoprammer.chip import *
+from libtoprammer.util import *
+
+
+class Chip_27cXXX_Dip40(Chip):
+	"Generic 27c1024 EPROM (16-bit)"
+
+	CTYPE_1024	= 0
+
+	# Chip sizes (in bytes)
+	ctype2size = {
+		CTYPE_1024	: 1024 * 1024 // 8,
+	}
+
+	# Programming voltages
+	vppTable = {
+		CTYPE_1024	: 12.75,
+	}
+
+	# Programming pulse lengths (in microseconds)
+	ppulseLengths = {
+		CTYPE_1024	: 100,
+	}
+
+	# Can we read the chip with VPP enabled?
+	readWithVPP = {
+		CTYPE_1024	: True,
+	}
+
+	# Chips that need overprogramming pulse.
+	# This may not be true for all manufacturers.
+	# Let the user set the chip option 'overprogram_pulse' in that case.
+	needOverprogram = {
+		CTYPE_1024	: False,
+	}
+
+	def __init__(self, chipType,
+		     chipPinVCC, chipPinVPP, chipPinGND):
+		Chip.__init__(self, chipPackage = "DIP40",
+			      chipPinVCC = chipPinVCC,
+			      chipPinsVPP = chipPinVPP,
+			      chipPinGND = chipPinGND)
+		self.chipType = chipType
+		self.generic = GenericAlgorithms(self)
+		self.addrSetter = AddrSetter(self, 0, 1)
+
+	def readSignature(self):
+		vppVolt = self.getChipOptionValue(
+			"vpp_voltage",
+			self.vppTable[self.chipType])
+		return self.__readSignature(vppVolt)
+		
+	def readEEPROM(self):
+		self.__turnOn()
+		return self.__readimage(self.ctype2size[self.chipType])
+	
+	def __readimage(self, sizeBytes):
+		"""Simple 8-bit data read algorithm."""
+		self.progressMeterInit("Reading EEPROM", sizeBytes/2)
+		image, count = [], 0
+		self.__setFlags(oe=0, ce=0)
+		self.addrSetter.reset()
+		for addr in range(0, sizeBytes/2):
+			self.progressMeter(addr)
+			self.addrSetter.load(addr)
+			self.__dataRead()
+			count += 2
+			if count == self.top.getBufferRegSize():
+				image.append(self.top.cmdReadBufferReg())
+				count = 0
+		if count:
+			image.append(self.top.cmdReadBufferReg()[:count])
+		self.__setFlags(oe=1, ce=1)
+		self.progressMeterFinish()
+		return b"".join(image)
+
+	def writeEEPROM(self, image):
+		sizeBytes = self.ctype2size[self.chipType]
+		if len(image) > sizeBytes:
+			self.throwError("Invalid image size. "
+				"Got %d bytes, but EPROM is only %d bytes." %\
+				(len(image), sizeBytes))
+
+		# Get the options
+		immediateVerify = self.getChipOptionValue(
+			"immediate_verify",
+			self.readWithVPP[self.chipType])
+		vppVolt = self.getChipOptionValue(
+			"vpp_voltage",
+			self.vppTable[self.chipType])
+		progpulseUsec = self.getChipOptionValue(
+			"ppulse_length",
+			self.ppulseLengths[self.chipType])
+
+		# Run the write algorithm
+		self.__writeAlgo(image, vppVolt, immediateVerify, progpulseUsec)
+
+	def __writeAlgo(self, image, vppVolt, immediateVerify, progpulseUsec):
+		self.printInfo("Using %.2f VPP" % vppVolt)
+		self.printInfo("Using %s verify." %\
+			("immediate" if immediateVerify else "detached"))
+		if immediateVerify and not self.readWithVPP[self.chipType]:
+			self.printWarning("Immediate verify will be slow "
+				"on this chip!")
+		self.printInfo("Using ppulse length: %d microseconds" %\
+			progpulseUsec)
+
+		self.__turnOn()
+		self.addrSetter.reset()
+		self.applyVPP(False)
+		self.top.cmdSetVPPVoltage(vppVolt)
+		okMask = [ False ] * (len(image)/2)
+		nrRetries = 25
+		for retry in range(0, nrRetries):
+			# Program
+			self.progressMeterInit("Writing EPROM", len(image)/2)
+			self.__setFlags(data_en=1, prog_en=1, ce=0, oe=1)
+			self.applyVPP(True, [1])
+			for addr in range(0, len(image)/2):
+				self.progressMeter(addr)
+				if okMask[addr]:
+					continue
+				img_addr = addr*2
+				data = byte2int(image[img_addr]) + (byte2int(image[img_addr+1]) << 8)
+				if data == 0xFFFF:
+					okMask[addr] = True
+				else:
+					self.__writeWord(addr, data,
+						immediateVerify, progpulseUsec)
+			self.applyVPP(False)
+			self.__setFlags(data_en=0, prog_en=0, ce=0, oe=0)
+			self.progressMeterFinish()
+			if immediateVerify:
+				break
+			if all(okMask):
+				break
+			# Detached verify
+			readImage = self.readimage()
+			for addr in range(0, len(image)):
+				if okMask[addr]:
+					continue
+				if image[addr] == readImage[addr]:
+					okMask[addr] = True
+			if all(okMask):
+				break
+			self.printInfo("%d of %d bytes failed verification. "
+				"Retrying those bytes..." %\
+				(len([ ok for ok in okMask if ok]),
+				 len(okMask)))
+		else:
+			self.throwError("Failed to write EPROM. "
+				"Tried %d times." % nrRetries)
+		self.__setFlags()
+		self.top.cmdSetVPPVoltage(5)
+
+	def __writeWord(self, addr, data,
+			doVerify, progpulseUsec):
+		self.addrSetter.load(addr)
+		self.__setDataPins(data)
+		for retry in range(0, 25):
+			self.__progPulse(progpulseUsec)
+			if not doVerify:
+				break
+			# Immediate verify
+			if not self.readWithVPP[self.chipType]:
+				self.applyVPP(False)
+			self.__setFlags(data_en=0, prog_en=0, ce=0, oe=0)
+			readData = self.__readWord(addr)
+			self.__setFlags(data_en=1, prog_en=1, ce=0, oe=1)
+			if not self.readWithVPP[self.chipType]:
+				self.applyVPP(True, [1])
+			if readData == data:
+				break
+		else:
+			self.throwError("Failed to write EPROM address %d" % addr)
+
+	def __readWord(self, addr):
+		self.addrSetter.load(addr)
+		self.__dataRead()
+		return self.top.cmdReadBufferReg16()
+
+	def __turnOn(self):
+		self.__setType(self.chipType)
+		self.__setFlags()
+		self.generic.simpleVoltageSetup()
+
+	def __setDataPins(self, value):
+		self.top.cmdFPGAWrite(2, value & 0xFF)
+		self.top.cmdFPGAWrite(3, value >> 8)
+
+	def __setFlags(self, data_en=0, prog_en=0, ce=1, oe=1):
+		value = 0
+		if data_en:
+			value |= (1 << 0)
+		if prog_en:
+			value |= (1 << 1)
+		if ce:
+			value |= (1 << 2)
+		if oe:
+			value |= (1 << 3)
+		self.top.cmdFPGAWrite(4, value)
+
+	def __progPulse(self, usec):
+		value = roundup(usec, 100) // 100
+		if value > 0x7F:
+			value = roundup(value, 8) // 8
+			if value > 0x7F:
+				self.throwError("__progPulse time too big")
+			value |= 0x80 # Set "times 8" multiplier
+		self.top.cmdFPGAWrite(5, value)
+		seconds = float(value & 0x7F) / 10000
+		if value & 0x80:
+			seconds *= 8
+		self.top.cmdDelay(seconds)
+		self.top.flushCommands()
+
+	def __setType(self, typeNumber):
+		self.top.cmdFPGAWrite(6, typeNumber)
+
+	def __dataRead(self):
+		self.top.cmdFPGARead(0)
+		self.top.cmdFPGARead(1)
+
+	def __readSignature(self, vppVolt):
+		self.addrSetter.reset()
+		self.__turnOn()
+		self.applyVPP(False)
+		self.top.cmdSetVPPVoltage(vppVolt)
+		self.__setFlags(oe=0, ce=0)
+		self.applyVPP(True, [31])
+		for addr in xrange(2):
+			self.addrSetter.load(addr)
+			self.__dataRead()
+		data = self.top.cmdReadBufferReg(4)
+		manufacturer = data[1] + data[0]
+		device = data[3] + data[2]
+		self.applyVPP(False)
+		self.__setFlags()
+		self.top.cmdSetVPPVoltage(5)
+		return manufacturer + device
+		
+		
+class ChipDescription_27cXXX_Dip40(ChipDescription):
+	"Generic 16-bit 27cXXX DIP40 ChipDescription"
+
+	def __init__(self, chipImplClass, name):
+		ChipDescription.__init__(self,
+			chipImplClass = chipImplClass,
+			bitfile = "_27cxxxdip40",
+			chipID = name,
+			runtimeID = (13, 1),
+			chipType = ChipDescription.TYPE_EPROM,
+			chipVendors = "Various",
+			description = name + " EPROM",
+			packages = ( ("DIP40", ""), ),
+			chipOptions = (
+				ChipOptionBool("immediate_verify",
+					"Immediately verify each written byte"),
+				ChipOptionFloat("vpp_voltage",
+					"Override the default VPP voltage",
+					minVal=10.0, maxVal=14.0),
+				ChipOptionInt("ppulse_length",
+					"Force 'Programming pulse' length, in microseconds.",
+					minVal=100, maxVal=10000),
+			)
+		)
+
+class Chip_27c1024(Chip_27cXXX_Dip40):
+	def __init__(self):
+		Chip_27cXXX_Dip40.__init__(self,
+			chipType = Chip_27cXXX_Dip40.CTYPE_1024,
+			chipPinVCC = 40,
+			chipPinVPP = [1, 31],
+			chipPinGND = 30)
+
+ChipDescription_27cXXX_Dip40(Chip_27c1024, "27c1024")

--- a/libtoprammer/chips/_28f102.py
+++ b/libtoprammer/chips/_28f102.py
@@ -1,0 +1,321 @@
+"""
+#    TOP2049 Open Source programming suite
+#
+#    28F102  Flash EEPROM
+#
+#    Copyright (c) 2012 Michael Buesch <m@bues.ch>
+#    Copyright (c) 2016 Tom van Leeuwen <gpl@tomvanleeuwen.nl>
+#
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License along
+#    with this program; if not, write to the Free Software Foundation, Inc.,
+#    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+from libtoprammer.chip import *
+from libtoprammer.util import *
+
+import math
+
+class Chip_28fXXX_Dip40(Chip):
+	"Generic 28f1024 Flash Memory (16-bit)"
+
+	CTYPE_1024	= 0
+
+	# Chip sizes (in bytes)
+	ctype2size = {
+		CTYPE_1024	: 1024 * 1024 // 8,
+	}
+
+	# Programming voltages
+	vppTable = {
+		CTYPE_1024	: 12.75,
+	}
+
+	# Programming pulse lengths (in microseconds)
+	ppulseLengths = {
+		CTYPE_1024	: 100,
+	}
+
+	# Can we read the chip with VPP enabled?
+	readWithVPP = {
+		CTYPE_1024	: True,
+	}
+
+	# Chips that need overprogramming pulse.
+	# This may not be true for all manufacturers.
+	# Let the user set the chip option 'overprogram_pulse' in that case.
+	needOverprogram = {
+		CTYPE_1024	: False,
+	}
+	
+	# The time in seconds between the erase and erase-verify (which stops the erase process)
+	eraseDelay		= 0.010
+	
+	CMD_READ		= 0x00
+	CMD_READ_SIG		= 0x90
+	CMD_ERASE		= 0x20
+	CMD_ERASE_VERIFY	= 0xA0
+	CMD_PROGRAM		= 0x40
+	CMD_PROGRAM_VERIFY	= 0xC0
+	CMD_RESET		= 0xFF
+	
+	def __init__(self, chipType,
+		     chipPinVCC, chipPinVPP, chipPinGND):
+		Chip.__init__(self, chipPackage = "DIP40",
+			      chipPinVCC = chipPinVCC,
+			      chipPinsVPP = chipPinVPP,
+			      chipPinGND = chipPinGND)
+		self.chipType = chipType
+		self.generic = GenericAlgorithms(self)
+		self.addrSetter = AddrSetter(self, 0, 1)
+
+	def readSignature(self):
+		vppVolt = self.getChipOptionValue(
+			"vpp_voltage",
+			self.vppTable[self.chipType])
+		return self.__readSignature(vppVolt)
+		
+	def readEEPROM(self):
+		self.__turnOn()
+		return self.__readimage(self.ctype2size[self.chipType])
+	
+	def erase(self):
+		vppVolt = self.getChipOptionValue(
+			"vpp_voltage",
+			self.vppTable[self.chipType])
+		writeZero = self.getChipOptionValue(
+			"zero_before_erase", True)
+		self.__eraseAlgo(vppVolt, self.ctype2size[self.chipType], writeZero)
+	
+	def __readimage(self, sizeBytes):
+		"""Simple 8-bit data read algorithm."""
+		self.progressMeterInit("Reading EEPROM", sizeBytes/2)
+		image, count = [], 0
+		self.__setFlags(oe=0, ce=0)
+		self.addrSetter.reset()
+		for addr in range(0, sizeBytes/2):
+			self.progressMeter(addr)
+			self.addrSetter.load(addr)
+			self.__dataRead(False)
+			count += 2
+			if count == self.top.getBufferRegSize():
+				image.append(self.top.cmdReadBufferReg())
+				count = 0
+		if count:
+			image.append(self.top.cmdReadBufferReg()[:count])
+		self.__setFlags(oe=1, ce=1)
+		self.progressMeterFinish()
+		return b"".join(image)
+
+	def writeEEPROM(self, image):
+		sizeBytes = self.ctype2size[self.chipType]
+		if len(image) > sizeBytes:
+			self.throwError("Invalid image size. "
+				"Got %d bytes, but EEPROM is only %d bytes." %\
+				(len(image), sizeBytes))
+
+		# Get the options
+		vppVolt = self.getChipOptionValue(
+			"vpp_voltage",
+			self.vppTable[self.chipType])
+
+		# Run the write algorithm
+		self.__writeAlgo(image, vppVolt)
+
+	def __writeAlgo(self, image, vppVolt):
+		self.printInfo("Using %.2f VPP" % vppVolt)
+
+		self.__turnOn()
+		self.addrSetter.reset()
+		self.applyVPP(False)
+		self.top.cmdSetVPPVoltage(vppVolt)
+		# Program
+		self.progressMeterInit("Writing EEPROM", len(image)/2)
+		self.__setFlags(data_en=1, prog_en=1, ce=0, oe=1)
+		self.applyVPP(True, [1])
+		for addr in range(0, len(image)/2):
+			self.progressMeter(addr)
+			img_addr = addr*2
+			data = byte2int(image[img_addr]) + (byte2int(image[img_addr+1]) << 8)
+			self.__writeWord(addr, data)
+			
+		self.__dataWrite(self.CMD_READ)
+		self.applyVPP(False)
+		self.__setFlags()
+		self.top.cmdSetVPPVoltage(5)
+
+	def __writeWord(self, addr, data):
+		self.addrSetter.load(addr)
+		for retry in range(0, 25):
+			self.__dataWrite(self.CMD_PROGRAM)
+			self.__dataWrite(data)
+			self.__dataWrite(self.CMD_PROGRAM_VERIFY)
+			self.__setFlags(data_en=0, prog_en=0, ce=0, oe=0)
+			readData = self.__dataRead(True)
+			self.__setFlags(data_en=1, prog_en=1, ce=0, oe=1)
+			if readData == data:
+				break
+		else:
+			self.throwError("Failed to write EEPROM address %d" % addr)
+
+	def __eraseAlgo(self, vppVolt, sizeBytes, writeZero):
+		self.printInfo("Using %.2f VPP" % vppVolt)
+		
+		self.__turnOn()
+		self.addrSetter.reset()
+		self.applyVPP(False)
+		self.top.cmdSetVPPVoltage(vppVolt)
+		self.__setFlags(data_en=1, prog_en=1, oe=1, ce=0)
+		self.applyVPP(True, [1])
+		
+		# First overwrite everything with 0x0000
+		if writeZero:
+			self.printInfo("Overwrite chip with zero-data")
+			self.progressMeterInit("Clearing data", sizeBytes/2)
+			for addr in range(0, sizeBytes/2):
+				self.progressMeter(addr)
+				self.__writeWord(addr, 0)
+		
+		# Use the first non-zero address for the progress bar
+		nonzero_address = 0
+		self.printInfo("Erasing chip")
+		self.progressMeterInit("Erasing chip", sizeBytes/2)
+		# Execute Erase command
+		for retry in range(0, 1000):
+			self.__dataWrite(self.CMD_ERASE)
+			self.__dataWrite(self.CMD_ERASE)
+			self.top.hostDelay(self.eraseDelay)
+			for addr in range(nonzero_address, sizeBytes/2):
+				if not self.__eraseVerify(addr):
+					break
+				nonzero_address = addr
+				self.progressMeter(addr)
+			else:
+				break
+		else:
+			self.throwError("Failed to erase EEPROM")
+			
+		self.__dataWrite(self.CMD_READ)
+		self.applyVPP(False)
+		self.__setFlags()
+		self.top.cmdSetVPPVoltage(5)
+		
+	def __eraseVerify(self, addr):
+		self.addrSetter.load(addr)
+		self.__dataWrite(self.CMD_ERASE_VERIFY)
+		self.__setFlags(data_en=0, prog_en=0, ce=0, oe=0)
+		readData = self.__dataRead(True)
+		self.__setFlags(data_en=1, prog_en=1, ce=0, oe=1)
+		return readData == 0xFFFF
+
+	def __readWord(self, addr):
+		self.addrSetter.load(addr)
+		return self.__dataRead(True)
+
+	def __turnOn(self):
+		self.__setType(self.chipType)
+		self.__setFlags()
+		self.generic.simpleVoltageSetup()
+
+	def __setDataPins(self, value):
+		self.top.cmdFPGAWrite(2, value & 0xFF)
+		self.top.cmdFPGAWrite(3, value >> 8)
+
+	def __setFlags(self, data_en=0, prog_en=0, ce=1, oe=1):
+		value = 0
+		if data_en:
+			value |= (1 << 0)
+		if prog_en:
+			value |= (1 << 1)
+		if ce:
+			value |= (1 << 2)
+		if oe:
+			value |= (1 << 3)
+		self.top.cmdFPGAWrite(4, value)
+
+	def __progPulse(self, usec):
+		value = roundup(usec, 100) // 100
+		if value > 0x7F:
+			value = roundup(value, 8) // 8
+			if value > 0x7F:
+				self.throwError("__progPulse time too big")
+			value |= 0x80 # Set "times 8" multiplier
+		self.top.cmdFPGAWrite(5, value)
+		seconds = float(value & 0x7F) / 10000
+		if value & 0x80:
+			seconds *= 8
+		self.top.cmdDelay(seconds)
+		self.top.flushCommands()
+
+	def __setType(self, typeNumber):
+		self.top.cmdFPGAWrite(6, typeNumber)
+
+	def __dataRead(self, returnData=False):
+		self.top.cmdFPGARead(0)
+		self.top.cmdFPGARead(1)
+		if returnData:
+			return self.top.cmdReadBufferReg16()
+		
+	def __dataWrite(self, data):
+		self.__setDataPins(data)
+		self.__progPulse(self.ppulseLengths[self.chipType])
+
+	def __readSignature(self, vppVolt):
+		self.addrSetter.reset()
+		self.__turnOn()
+		self.applyVPP(False)
+		self.top.cmdSetVPPVoltage(vppVolt)
+		self.__setFlags(oe=0, ce=0)
+		self.applyVPP(True, [31])
+		for addr in xrange(2):
+			self.addrSetter.load(addr)
+			self.__dataRead(False)
+		data = self.top.cmdReadBufferReg(4)
+		manufacturer = data[1] + data[0]
+		device = data[3] + data[2]
+		self.applyVPP(False)
+		self.__setFlags()
+		self.top.cmdSetVPPVoltage(5)
+		return manufacturer + device
+		
+		
+class ChipDescription_28fXXX_Dip40(ChipDescription):
+	"Generic 16-bit 28fXXX DIP40 ChipDescription"
+
+	def __init__(self, chipImplClass, name):
+		ChipDescription.__init__(self,
+			chipImplClass = chipImplClass,
+			bitfile = "_27cxxxdip40", # Use 27c1024 bitfile, it is compatible.
+			chipID = name,
+			runtimeID = (13, 1),
+			chipType = ChipDescription.TYPE_EEPROM,
+			chipVendors = "Various",
+			description = name + " EEPROM",
+			packages = ( ("DIP40", ""), ),
+			chipOptions = (
+				ChipOptionBool("zero_before_erase",
+					"Write zero-data before erase operation"),
+				ChipOptionFloat("vpp_voltage",
+					"Override the default VPP voltage",
+					minVal=10.0, maxVal=14.0),
+			)
+		)
+
+class Chip_28f102(Chip_28fXXX_Dip40):
+	def __init__(self):
+		Chip_28fXXX_Dip40.__init__(self,
+			chipType = Chip_28fXXX_Dip40.CTYPE_1024,
+			chipPinVCC = 40,
+			chipPinVPP = [1, 31],
+			chipPinGND = 30)
+
+ChipDescription_28fXXX_Dip40(Chip_28f102, "28f102")

--- a/libtoprammer/chips/__init__.py
+++ b/libtoprammer/chips/__init__.py
@@ -2,6 +2,7 @@
 
 from _27cxxx import *
 from _27c1024 import *
+from _28f102 import *
 from _74hc4094 import *
 from at89c2051dip20 import *
 from at89s51dip40 import *

--- a/libtoprammer/chips/__init__.py
+++ b/libtoprammer/chips/__init__.py
@@ -1,6 +1,7 @@
 # Import all chip modules in **ALPHABETICAL** order
 
 from _27cxxx import *
+from _27c1024 import *
 from _74hc4094 import *
 from at89c2051dip20 import *
 from at89s51dip40 import *

--- a/libtoprammer/fpga/src/_27cxxxdip40/Makefile
+++ b/libtoprammer/fpga/src/_27cxxxdip40/Makefile
@@ -1,0 +1,2 @@
+NAME:=_27cxxxdip40
+include ../../common/makefile

--- a/libtoprammer/fpga/src/_27cxxxdip40/_27cxxxdip40.v
+++ b/libtoprammer/fpga/src/_27cxxxdip40/_27cxxxdip40.v
@@ -1,0 +1,197 @@
+/*
+ *   TOP2049 Open Source programming suite
+ *
+ *   27c1024dip40  UV/OTP EPROM
+ *   Various manufacturers
+ *
+ *   FPGA bottomhalf implementation
+ *
+ *   Copyright (c) 2012 Michael Buesch <m@bues.ch>
+ *   Copyright (c) 2016 Tom van Leeuwen <gpl@tomvanleeuwen.nl>
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License along
+ *   with this program; if not, write to the Free Software Foundation, Inc.,
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+`include "common.vh"
+
+`BOTTOMHALF_BEGIN(_27cxxxdip40, 13, 1)
+	reg [15:0] cdata;
+	reg cdata_en;
+	reg [15:0] caddr;
+	reg ce;			/* !CE */
+	reg prog_pulse_reg;	/* Programming pulse */
+	reg [9:0] prog_pulse_length;
+	reg [9:0] prog_pulse_count;
+	reg prog_en;
+	reg oe;			/* !OE */
+
+	reg [2:0] ctype;	/* Chip type */
+	`define CTYPE_1024		0
+
+	`define CMD_PPULSE		0
+
+	initial begin
+		cdata <= 0;
+		cdata_en <= 0;
+		caddr <= 0;
+		ce <= 1;
+		prog_pulse_reg <= 1;
+		prog_pulse_length <= 0;
+		prog_pulse_count <= 0;
+		prog_en <= 0;
+		oe <= 1;
+		ctype <= 0;
+	end
+
+	wire prog_pulse;
+	assign prog_pulse = prog_en ? prog_pulse_reg : high;
+
+	`ASYNCPROC_BEGIN
+		if (`CMD_IS(`CMD_PPULSE)) begin
+			case (`CMD_STATE)
+			0: begin
+				prog_pulse_count <= prog_pulse_length;
+				`CMD_STATE_SET(1)
+			end
+			1: begin
+				prog_pulse_reg <= 0;
+				prog_pulse_count <= prog_pulse_count - 1;
+				`CMD_STATE_SET(2)
+				`UDELAY(100)
+			end
+			2: begin
+				if (prog_pulse_count == 0) begin
+					prog_pulse_reg <= 1;
+					`CMD_FINISH
+				end else begin
+					`CMD_STATE_SET(1)
+				end
+			end
+			endcase
+		end
+	`ASYNCPROC_END
+
+	`DATAWRITE_BEGIN
+		`ADDR(0): begin /* Address low write */
+			caddr[7:0] <= in_data[7:0];
+		end
+		`ADDR(1): begin /* Address high write */
+			caddr[15:8] <= in_data[7:0];
+		end
+		`ADDR(2): begin /* Data pins write */
+			cdata[7:0] <= in_data[7:0];
+		end
+		`ADDR(3): begin /* Data pins write */
+			cdata[15:8] <= in_data[7:0];
+		end
+		`ADDR(4): begin /* Flags write */
+			cdata_en <= in_data[0];
+			prog_en <= in_data[1];
+			ce <= in_data[2];
+			oe <= in_data[3];
+		end
+		`ADDR(5): begin /* Perform prog pulse */
+			/* in_data[6:0] -> ppulse length, in 100us units.
+			 * in_data[7] -> Length multiplier "times 8".
+			 */
+			if (in_data[7]) begin
+				prog_pulse_length[2:0] <= 0;
+				prog_pulse_length[9:3] <= in_data[6:0];
+			end else begin
+				prog_pulse_length[6:0] <= in_data[6:0];
+				prog_pulse_length[9:7] <= 0;
+			end
+			`CMD_RUN(`CMD_PPULSE)
+		end
+		`ADDR(6): begin /* Set the chip type number */
+			ctype[2:0] <= in_data[2:0];
+		end
+	`DATAWRITE_END
+
+	`DATAREAD_BEGIN
+		`ADDR(0): begin /* Data pins read, low byte */
+			out_data[0] <= zif[23]; /* Note: pinning is in reversed order. */
+			out_data[1] <= zif[22];
+			out_data[2] <= zif[21];
+			out_data[3] <= zif[20];
+			out_data[4] <= zif[19];
+			out_data[5] <= zif[18];
+			out_data[6] <= zif[17];
+			out_data[7] <= zif[16];
+		end
+		`ADDR(1): begin /* Data pins read, high byte */
+			out_data[0] <= zif[14]; /* Note: pinning is in reversed order */
+			out_data[1] <= zif[13];
+			out_data[2] <= zif[12];
+			out_data[3] <= zif[11];
+			out_data[4] <= zif[10];
+			out_data[5] <= zif[9];
+			out_data[6] <= zif[8];
+			out_data[7] <= zif[7];
+		end
+		`ADDR(2): begin /* Flags read */
+			out_data[0] <= `CMD_IS_RUNNING;
+			out_data[7:1] <= 0;
+		end
+	`DATAREAD_END
+	
+	
+	`ZIF_UNUSED(1)	`ZIF_UNUSED(2)	`ZIF_UNUSED(3)
+	`ZIF_UNUSED(4)
+	// Top of chip, add 4 to DIL40 pin numbers to get ZIF pin number
+	bufif0(zif[5], low, high);			/* VPP */
+	bufif0(zif[6], ce, low);			/* CE */
+	bufif0(zif[7], cdata[15], !cdata_en);		/* O15 */
+	bufif0(zif[8], cdata[14], !cdata_en);		/* O14 */
+	bufif0(zif[9], cdata[13], !cdata_en);		/* O13 */
+	bufif0(zif[10], cdata[12], !cdata_en);		/* O12 */
+	bufif0(zif[11], cdata[11], !cdata_en);		/* O11 */
+	bufif0(zif[12], cdata[10], !cdata_en);		/* O10 */
+	bufif0(zif[13], cdata[9], !cdata_en);		/* O9 */
+	bufif0(zif[14], cdata[8], !cdata_en);		/* O8 */
+	bufif0(zif[15], low, low);			/* GND */
+	bufif0(zif[16], cdata[7], !cdata_en);		/* O8 */
+	bufif0(zif[17], cdata[6], !cdata_en);		/* O8 */
+	bufif0(zif[18], cdata[5], !cdata_en);		/* O8 */
+	bufif0(zif[19], cdata[4], !cdata_en);		/* O8 */
+	bufif0(zif[20], cdata[3], !cdata_en);		/* O8 */
+	bufif0(zif[21], cdata[2], !cdata_en);		/* O8 */
+	bufif0(zif[22], cdata[1], !cdata_en);		/* O8 */
+	bufif0(zif[23], cdata[0], !cdata_en);		/* O8 */
+	bufif0(zif[24], oe, low);			/* !OE */
+	// Bottom of chip
+	bufif0(zif[25], caddr[0], low);			/* A0 */
+	bufif0(zif[26], caddr[1], low);			/* A1 */
+	bufif0(zif[27], caddr[2], low);			/* A2 */
+	bufif0(zif[28], caddr[3], low);			/* A3 */
+	bufif0(zif[29], caddr[4], low);			/* A4 */
+	bufif0(zif[30], caddr[5], low);			/* A5 */
+	bufif0(zif[31], caddr[6], low);			/* A6 */
+	bufif0(zif[32], caddr[7], low);			/* A7 */
+	bufif0(zif[33], caddr[8], low);			/* A8 */
+	bufif0(zif[34], low, low);			/* GND */
+	bufif0(zif[35], caddr[9], low);			/* A9 */
+	bufif0(zif[36], caddr[10], low);		/* A10 */
+	bufif0(zif[37], caddr[11], low);		/* A11 */
+	bufif0(zif[38], caddr[12], low);		/* A12 */
+	bufif0(zif[39], caddr[13], low);		/* A13 */
+	bufif0(zif[40], caddr[14], low);		/* A14 */
+	bufif0(zif[41], caddr[15], low);		/* A15 */
+	`ZIF_UNUSED(42)
+	bufif0(zif[43], prog_pulse, low);		/* A15 */
+	bufif0(zif[44], high, high);			/* VCC (>= 64) */
+	`ZIF_UNUSED(45)	`ZIF_UNUSED(46)	`ZIF_UNUSED(47)
+	`ZIF_UNUSED(48)
+`BOTTOMHALF_END

--- a/libtoprammer/main.py
+++ b/libtoprammer/main.py
@@ -199,7 +199,15 @@ class TOP(object):
 			(r"top2049\s+ver\s*(\d+\.\d+)", self.TYPE_TOP2049),
 		)
 
-		versionString = self.hw.readVersionString()
+		# This is the first hardware access. Try several times since the programmer is in an unknown state.
+		for _ in range(25):
+			try:
+				versionString = self.hw.readVersionString()
+				break
+			except TOPException, e:
+				pass
+		else:
+			raise TOPException("Could not read version string from hardware")
 		for (regex, t) in versionRegex:
 			if t != self.topType:
 				continue


### PR DESCRIPTION
Hi Michael,

I recently found libtoprammer, and I wish I had found it before. I especially like it since it runs on Linux and since I can add support for the CAT28F102 flash chip (which is not present in the original software)

I added support for the 27C1024 and 28F102 to libtoprammer.
I currently have not tested the write function of the 27C1024, since I only have OT-PROM's.
The 28F102 works correctly with my CAT28F102N-90.
The code reads the device ID and manufacturer ID as "signature", which is not present in the 27cxxx version, but I thought it would be nice to have.

I also added a little hack that re-tries reading the version string (4b9ea36) since this is the first action on the USB bus. I often had problems running libtoprammer for a second time without disconnecting/reconnecting the programmer (especially when using the GUI or when an exception occurs), but this fixes that problem.

I am planning to test the write function of the 27C1024 by flipping some bits to zero on an old OT-PROM, I will let you know if it works.

I am also thinking of a function that checks the connectivity of all pins, by applying VCC to the GND pin and having all other pins floating (due to the ESD protection diodes, all pins shall be high), Applying GND to the VCC pin will do the same check in reverse, but I think the TOP2049 will always read '0' if a pin is not connected. Checking pin connectivity is important for me since I use a PLCC44 converter in combination with OTPROMS, so a floating pin is quite common but it would ruin the chip.

Regards,

Tom
