### PR TITLE
Retry init

### DIFF
--- a/libtoprammer/main.py
+++ b/libtoprammer/main.py
@@ -199,7 +199,15 @@ class TOP(object):
 			(r"top2049\s+ver\s*(\d+\.\d+)", self.TYPE_TOP2049),
 		)
 
-		versionString = self.hw.readVersionString()
+		# This is the first hardware access. Try several times since the programmer is in an unknown state.
+		for _ in range(25):
+			try:
+				versionString = self.hw.readVersionString()
+				break
+			except TOPException, e:
+				pass
+		else:
+			raise TOPException("Could not read version string from hardware")
 		for (regex, t) in versionRegex:
 			if t != self.topType:
 				continue

--- a/libtoprammer/main.py
+++ b/libtoprammer/main.py
@@ -200,12 +200,12 @@ class TOP(object):
 		)
 
 		# This is the first hardware access. Try several times since the programmer is in an unknown state.
-		for _ in range(25):
+		for _ in range(5):
 			try:
 				versionString = self.hw.readVersionString()
 				break
 			except TOPException, e:
-				pass
+				time.sleep(0.05)
 		else:
 			raise TOPException("Could not read version string from hardware")
 		for (regex, t) in versionRegex:


### PR DESCRIPTION
Hereby the initialization retry code as separate pull-request.

The difference between the 27c512 and 27c1024 is that the 27c1024 is a 16-bit eeprom, e.g. there are 16 data pins. As a result, it has a completely different package and pinout, but the control is exactly identical. I think even if you would make the verilog code compatible with both pinouts, the logic to switch between the two pinouts makes it more error-prone and you would still need to test the 8-bit and 16-bits separately.

Regards,

Tom
